### PR TITLE
refactor: streamline settings menu

### DIFF
--- a/admin/class-wp-3d-model-viewer-admin.php
+++ b/admin/class-wp-3d-model-viewer-admin.php
@@ -1,5 +1,4 @@
 <?php
-
 /**
  * The admin-specific functionality of the plugin.
  *
@@ -44,14 +43,13 @@ class WP_3D_Model_Viewer_Admin {
 	 * Initialize the class and set its properties.
 	 *
 	 * @since    1.0.0
-	 * @param      string    $plugin_name       The name of this plugin.
-	 * @param      string    $version    The version of this plugin.
+	 * @param      string $plugin_name       The name of this plugin.
+	 * @param      string $version    The version of this plugin.
 	 */
 	public function __construct( $plugin_name, $version ) {
 
 		$this->plugin_name = $plugin_name;
-		$this->version = $version;
-
+		$this->version     = $version;
 	}
 
 	/**
@@ -74,7 +72,6 @@ class WP_3D_Model_Viewer_Admin {
 		 */
 
 		wp_enqueue_style( $this->plugin_name, plugin_dir_url( __FILE__ ) . 'css/wp-3d-model-viewer-admin.css', array(), $this->version, 'all' );
-
 	}
 
 	/**
@@ -97,43 +94,23 @@ class WP_3D_Model_Viewer_Admin {
 		 */
 
 		wp_enqueue_script( $this->plugin_name, plugin_dir_url( __FILE__ ) . 'js/wp-3d-model-viewer-admin.js', array( 'jquery' ), $this->version, false );
-
 	}
 
-	/**
-	 * Register the administration menu for this plugin into the WordPress Dashboard menu.
-	 *
-	 * @since    1.0.0
-	 */
-	public function add_plugin_admin_menu() {
-
-		/*
-		 * Add a settings page for this plugin to the Settings menu.
+		/**
+		 * Initialize WordPress Settings API.
+		 *
+		 * @since    1.0.0
 		 */
-		add_options_page( 
-			__( 'WP 3D Model Viewer Settings', 'wp-3d-model-viewer' ), 
-			__( '3D Viewer', 'wp-3d-model-viewer' ), 
-			'manage_options', 
-			'wp-3d-model-viewer', 
-			array( $this, 'display_plugin_setup_page' )
-		);
-	}
-
-	/**
-	 * Initialize WordPress Settings API.
-	 *
-	 * @since    1.0.0
-	 */
 	public function admin_init() {
-		
-		// Register settings
+
+				// Register settings.
 		register_setting(
 			'wp_3d_model_viewer_settings',
 			'wp_3d_model_viewer_options',
 			array( $this, 'validate_options' )
 		);
 
-		// Add settings sections
+				// Add settings sections.
 		add_settings_section(
 			'wp_3d_model_viewer_general',
 			__( 'General Settings', 'wp-3d-model-viewer' ),
@@ -155,7 +132,7 @@ class WP_3D_Model_Viewer_Admin {
 			'wp-3d-model-viewer'
 		);
 
-		// Add settings fields
+				// Add settings fields.
 		$this->add_settings_fields();
 	}
 
@@ -165,8 +142,8 @@ class WP_3D_Model_Viewer_Admin {
 	 * @since    1.0.0
 	 */
 	private function add_settings_fields() {
-		
-		// General settings fields
+
+				// General settings fields.
 		add_settings_field(
 			'default_background_color',
 			__( 'Default Background Color', 'wp-3d-model-viewer' ),
@@ -199,7 +176,7 @@ class WP_3D_Model_Viewer_Admin {
 			'wp_3d_model_viewer_general'
 		);
 
-		// MIME type settings fields
+				// MIME type settings fields.
 		add_settings_field(
 			'allowed_mime_types',
 			__( 'Allowed MIME Types', 'wp-3d-model-viewer' ),
@@ -216,7 +193,7 @@ class WP_3D_Model_Viewer_Admin {
 			'wp_3d_model_viewer_mime'
 		);
 
-		// Advanced settings fields
+				// Advanced settings fields.
 		add_settings_field(
 			'enable_debugging',
 			__( 'Enable Debugging', 'wp-3d-model-viewer' ),
@@ -247,7 +224,7 @@ class WP_3D_Model_Viewer_Admin {
 	 * @since    1.0.0
 	 */
 	public function general_section_callback() {
-		echo '<p>' . __( 'Configure default settings for 3D model viewers.', 'wp-3d-model-viewer' ) . '</p>';
+			echo '<p>' . esc_html__( 'Configure default settings for 3D model viewers.', 'wp-3d-model-viewer' ) . '</p>';
 	}
 
 	/**
@@ -256,7 +233,7 @@ class WP_3D_Model_Viewer_Admin {
 	 * @since    1.0.0
 	 */
 	public function mime_section_callback() {
-		echo '<p>' . __( 'Configure which file types are allowed for 3D model uploads.', 'wp-3d-model-viewer' ) . '</p>';
+			echo '<p>' . esc_html__( 'Configure which file types are allowed for 3D model uploads.', 'wp-3d-model-viewer' ) . '</p>';
 	}
 
 	/**
@@ -265,7 +242,7 @@ class WP_3D_Model_Viewer_Admin {
 	 * @since    1.0.0
 	 */
 	public function advanced_section_callback() {
-		echo '<p>' . __( 'Advanced configuration options and debugging features.', 'wp-3d-model-viewer' ) . '</p>';
+			echo '<p>' . esc_html__( 'Advanced configuration options and debugging features.', 'wp-3d-model-viewer' ) . '</p>';
 	}
 
 	/**
@@ -275,10 +252,10 @@ class WP_3D_Model_Viewer_Admin {
 	 */
 	public function background_color_field_callback() {
 		$options = get_option( 'wp_3d_model_viewer_options' );
-		$value = isset( $options['default_background_color'] ) ? $options['default_background_color'] : '#ffffff';
-		
+		$value   = isset( $options['default_background_color'] ) ? $options['default_background_color'] : '#ffffff';
+
 		echo '<input type="color" id="default_background_color" name="wp_3d_model_viewer_options[default_background_color]" value="' . esc_attr( $value ) . '" />';
-		echo '<p class="description">' . __( 'Default background color for 3D model viewers.', 'wp-3d-model-viewer' ) . '</p>';
+				echo '<p class="description">' . esc_html__( 'Default background color for 3D model viewers.', 'wp-3d-model-viewer' ) . '</p>';
 	}
 
 	/**
@@ -288,12 +265,12 @@ class WP_3D_Model_Viewer_Admin {
 	 */
 	public function zoom_level_field_callback() {
 		$options = get_option( 'wp_3d_model_viewer_options' );
-		$value = isset( $options['default_zoom_level'] ) ? $options['default_zoom_level'] : '1.0';
-		
+		$value   = isset( $options['default_zoom_level'] ) ? $options['default_zoom_level'] : '1.0';
+
 		echo '<input type="range" id="default_zoom_level" name="wp_3d_model_viewer_options[default_zoom_level]" value="' . esc_attr( $value ) . '" min="0.1" max="5.0" step="0.1" />';
 		echo '<span class="zoom-display">' . esc_html( $value ) . 'x</span>';
-		echo '<p class="description">' . __( 'Default zoom level for 3D model viewers (0.1x to 5.0x).', 'wp-3d-model-viewer' ) . '</p>';
-		
+				echo '<p class="description">' . esc_html__( 'Default zoom level for 3D model viewers (0.1x to 5.0x).', 'wp-3d-model-viewer' ) . '</p>';
+
 		echo '<script>
 		document.getElementById("default_zoom_level").addEventListener("input", function() {
 			document.querySelector(".zoom-display").textContent = this.value + "x";
@@ -308,10 +285,10 @@ class WP_3D_Model_Viewer_Admin {
 	 */
 	public function default_width_field_callback() {
 		$options = get_option( 'wp_3d_model_viewer_options' );
-		$value = isset( $options['default_width'] ) ? $options['default_width'] : '100%';
-		
+		$value   = isset( $options['default_width'] ) ? $options['default_width'] : '100%';
+
 		echo '<input type="text" id="default_width" name="wp_3d_model_viewer_options[default_width]" value="' . esc_attr( $value ) . '" class="regular-text" />';
-		echo '<p class="description">' . __( 'Default width for 3D model viewers (e.g., 100%, 800px, 50em).', 'wp-3d-model-viewer' ) . '</p>';
+				echo '<p class="description">' . esc_html__( 'Default width for 3D model viewers (e.g., 100%, 800px, 50em).', 'wp-3d-model-viewer' ) . '</p>';
 	}
 
 	/**
@@ -321,10 +298,10 @@ class WP_3D_Model_Viewer_Admin {
 	 */
 	public function default_height_field_callback() {
 		$options = get_option( 'wp_3d_model_viewer_options' );
-		$value = isset( $options['default_height'] ) ? $options['default_height'] : '400px';
-		
+		$value   = isset( $options['default_height'] ) ? $options['default_height'] : '400px';
+
 		echo '<input type="text" id="default_height" name="wp_3d_model_viewer_options[default_height]" value="' . esc_attr( $value ) . '" class="regular-text" />';
-		echo '<p class="description">' . __( 'Default height for 3D model viewers (e.g., 400px, 50vh, 30em).', 'wp-3d-model-viewer' ) . '</p>';
+				echo '<p class="description">' . esc_html__( 'Default height for 3D model viewers (e.g., 400px, 50vh, 30em).', 'wp-3d-model-viewer' ) . '</p>';
 	}
 
 	/**
@@ -333,57 +310,57 @@ class WP_3D_Model_Viewer_Admin {
 	 * @since    1.0.0
 	 */
 	public function mime_types_field_callback() {
-		$options = get_option( 'wp_3d_model_viewer_options' );
+		$options       = get_option( 'wp_3d_model_viewer_options' );
 		$allowed_types = isset( $options['allowed_mime_types'] ) ? $options['allowed_mime_types'] : array();
-		
+
 		$mime_types = array(
-			'model/gltf+json' => array(
-				'label' => 'GLTF (.gltf)',
-				'extensions' => array( 'gltf' ),
-				'description' => 'GL Transmission Format (JSON variant)'
+			'model/gltf+json'          => array(
+				'label'       => 'GLTF (.gltf)',
+				'extensions'  => array( 'gltf' ),
+				'description' => 'GL Transmission Format (JSON variant)',
 			),
-			'model/gltf-binary' => array(
-				'label' => 'GLB (.glb)',
-				'extensions' => array( 'glb' ),
-				'description' => 'GL Transmission Format (Binary variant)'
+			'model/gltf-binary'        => array(
+				'label'       => 'GLB (.glb)',
+				'extensions'  => array( 'glb' ),
+				'description' => 'GL Transmission Format (Binary variant)',
 			),
 			'application/octet-stream' => array(
-				'label' => 'OBJ (.obj)',
-				'extensions' => array( 'obj' ),
-				'description' => 'Wavefront OBJ (requires MTL file)'
+				'label'       => 'OBJ (.obj)',
+				'extensions'  => array( 'obj' ),
+				'description' => 'Wavefront OBJ (requires MTL file)',
 			),
-			'application/x-tgif' => array(
-				'label' => 'FBX (.fbx)',
-				'extensions' => array( 'fbx' ),
-				'description' => 'Autodesk FBX format'
+			'application/x-tgif'       => array(
+				'label'       => 'FBX (.fbx)',
+				'extensions'  => array( 'fbx' ),
+				'description' => 'Autodesk FBX format',
 			),
-			'model/vnd.collada+xml' => array(
-				'label' => 'DAE (.dae)',
-				'extensions' => array( 'dae' ),
-				'description' => 'COLLADA Digital Asset Exchange'
+			'model/vnd.collada+xml'    => array(
+				'label'       => 'DAE (.dae)',
+				'extensions'  => array( 'dae' ),
+				'description' => 'COLLADA Digital Asset Exchange',
 			),
-			'model/vnd.usdz+zip' => array(
-				'label' => 'USDZ (.usdz)',
-				'extensions' => array( 'usdz' ),
-				'description' => 'USD (iOS AR format)'
+			'model/vnd.usdz+zip'       => array(
+				'label'       => 'USDZ (.usdz)',
+				'extensions'  => array( 'usdz' ),
+				'description' => 'USD (iOS AR format)',
 			),
-			'model/vnd.pixar.usd' => array(
-				'label' => 'USD (.usd)',
-				'extensions' => array( 'usd' ),
-				'description' => 'Universal Scene Description'
-			)
+			'model/vnd.pixar.usd'      => array(
+				'label'       => 'USD (.usd)',
+				'extensions'  => array( 'usd' ),
+				'description' => 'Universal Scene Description',
+			),
 		);
 
 		echo '<fieldset>';
 		foreach ( $mime_types as $mime_type => $info ) {
-			$checked = in_array( $mime_type, $allowed_types );
+						$checked = in_array( $mime_type, $allowed_types, true );
 			echo '<label>';
 			echo '<input type="checkbox" name="wp_3d_model_viewer_options[allowed_mime_types][]" value="' . esc_attr( $mime_type ) . '"' . checked( $checked, true, false ) . ' />';
 			echo ' <strong>' . esc_html( $info['label'] ) . '</strong> - ' . esc_html( $info['description'] );
 			echo '</label><br>';
 		}
 		echo '</fieldset>';
-		echo '<p class="description">' . __( 'Select which 3D model file formats are allowed for upload. Note: Your server must also support these MIME types.', 'wp-3d-model-viewer' ) . '</p>';
+				echo '<p class="description">' . esc_html__( 'Select which 3D model file formats are allowed for upload. Note: Your server must also support these MIME types.', 'wp-3d-model-viewer' ) . '</p>';
 	}
 
 	/**
@@ -393,11 +370,11 @@ class WP_3D_Model_Viewer_Admin {
 	 */
 	public function max_file_size_field_callback() {
 		$options = get_option( 'wp_3d_model_viewer_options' );
-		$value = isset( $options['max_file_size'] ) ? $options['max_file_size'] : '10';
-		
+		$value   = isset( $options['max_file_size'] ) ? $options['max_file_size'] : '10';
+
 		echo '<input type="number" id="max_file_size" name="wp_3d_model_viewer_options[max_file_size]" value="' . esc_attr( $value ) . '" min="1" max="100" step="1" class="small-text" />';
 		echo ' MB';
-		echo '<p class="description">' . __( 'Maximum file size for 3D model uploads in megabytes (1-100 MB).', 'wp-3d-model-viewer' ) . '</p>';
+				echo '<p class="description">' . esc_html__( 'Maximum file size for 3D model uploads in megabytes (1-100 MB).', 'wp-3d-model-viewer' ) . '</p>';
 	}
 
 	/**
@@ -407,13 +384,13 @@ class WP_3D_Model_Viewer_Admin {
 	 */
 	public function debugging_field_callback() {
 		$options = get_option( 'wp_3d_model_viewer_options' );
-		$value = isset( $options['enable_debugging'] ) ? $options['enable_debugging'] : '0';
-		
+		$value   = isset( $options['enable_debugging'] ) ? $options['enable_debugging'] : '0';
+
 		echo '<label>';
 		echo '<input type="checkbox" id="enable_debugging" name="wp_3d_model_viewer_options[enable_debugging]" value="1"' . checked( $value, '1', false ) . ' />';
-		echo ' ' . __( 'Enable debug mode', 'wp-3d-model-viewer' );
+				echo ' ' . esc_html__( 'Enable debug mode', 'wp-3d-model-viewer' );
 		echo '</label>';
-		echo '<p class="description">' . __( 'Enable detailed logging and debugging information for troubleshooting. Only enable when needed as it may affect performance.', 'wp-3d-model-viewer' ) . '</p>';
+				echo '<p class="description">' . esc_html__( 'Enable detailed logging and debugging information for troubleshooting. Only enable when needed as it may affect performance.', 'wp-3d-model-viewer' ) . '</p>';
 	}
 
 	/**
@@ -423,13 +400,13 @@ class WP_3D_Model_Viewer_Admin {
 	 */
 	public function lazy_loading_field_callback() {
 		$options = get_option( 'wp_3d_model_viewer_options' );
-		$value = isset( $options['lazy_loading'] ) ? $options['lazy_loading'] : '1';
-		
+		$value   = isset( $options['lazy_loading'] ) ? $options['lazy_loading'] : '1';
+
 		echo '<label>';
 		echo '<input type="checkbox" id="lazy_loading" name="wp_3d_model_viewer_options[lazy_loading]" value="1"' . checked( $value, '1', false ) . ' />';
-		echo ' ' . __( 'Enable lazy loading', 'wp-3d-model-viewer' );
+				echo ' ' . esc_html__( 'Enable lazy loading', 'wp-3d-model-viewer' );
 		echo '</label>';
-		echo '<p class="description">' . __( 'Load 3D models only when they come into view (recommended for performance).', 'wp-3d-model-viewer' ) . '</p>';
+				echo '<p class="description">' . esc_html__( 'Load 3D models only when they come into view (recommended for performance).', 'wp-3d-model-viewer' ) . '</p>';
 	}
 
 	/**
@@ -439,37 +416,37 @@ class WP_3D_Model_Viewer_Admin {
 	 */
 	public function ar_default_field_callback() {
 		$options = get_option( 'wp_3d_model_viewer_options' );
-		$value = isset( $options['enable_ar_by_default'] ) ? $options['enable_ar_by_default'] : '0';
-		
+		$value   = isset( $options['enable_ar_by_default'] ) ? $options['enable_ar_by_default'] : '0';
+
 		echo '<label>';
 		echo '<input type="checkbox" id="enable_ar_by_default" name="wp_3d_model_viewer_options[enable_ar_by_default]" value="1"' . checked( $value, '1', false ) . ' />';
-		echo ' ' . __( 'Enable AR support by default', 'wp-3d-model-viewer' );
+				echo ' ' . esc_html__( 'Enable AR support by default', 'wp-3d-model-viewer' );
 		echo '</label>';
-		echo '<p class="description">' . __( 'Enable augmented reality viewing on compatible devices by default for new models.', 'wp-3d-model-viewer' ) . '</p>';
+				echo '<p class="description">' . esc_html__( 'Enable augmented reality viewing on compatible devices by default for new models.', 'wp-3d-model-viewer' ) . '</p>';
 	}
 
 	/**
 	 * Validate and sanitize options.
 	 *
 	 * @since    1.0.0
-	 * @param    array    $input    Raw input values.
+	 * @param    array $input    Raw input values.
 	 * @return   array              Sanitized values.
 	 */
 	public function validate_options( $input ) {
 		$output = array();
 
-		// Sanitize background color
+			// Sanitize background color.
 		if ( isset( $input['default_background_color'] ) ) {
 			$output['default_background_color'] = sanitize_hex_color( $input['default_background_color'] );
 		}
 
-		// Sanitize zoom level
+			// Sanitize zoom level.
 		if ( isset( $input['default_zoom_level'] ) ) {
-			$zoom = floatval( $input['default_zoom_level'] );
+			$zoom                         = floatval( $input['default_zoom_level'] );
 			$output['default_zoom_level'] = max( 0.1, min( 5.0, $zoom ) );
 		}
 
-		// Sanitize dimensions
+			// Sanitize dimensions.
 		if ( isset( $input['default_width'] ) ) {
 			$output['default_width'] = sanitize_text_field( $input['default_width'] );
 		}
@@ -478,31 +455,31 @@ class WP_3D_Model_Viewer_Admin {
 			$output['default_height'] = sanitize_text_field( $input['default_height'] );
 		}
 
-		// Sanitize MIME types
+			// Sanitize MIME types.
 		if ( isset( $input['allowed_mime_types'] ) && is_array( $input['allowed_mime_types'] ) ) {
-			$allowed_mimes = array(
+			$allowed_mimes                = array(
 				'model/gltf+json',
 				'model/gltf-binary',
 				'application/octet-stream',
 				'application/x-tgif',
 				'model/vnd.collada+xml',
 				'model/vnd.usdz+zip',
-				'model/vnd.pixar.usd'
+				'model/vnd.pixar.usd',
 			);
 			$output['allowed_mime_types'] = array_intersect( $input['allowed_mime_types'], $allowed_mimes );
 		} else {
 			$output['allowed_mime_types'] = array();
 		}
 
-		// Sanitize file size
+			// Sanitize file size.
 		if ( isset( $input['max_file_size'] ) ) {
-			$size = intval( $input['max_file_size'] );
+			$size                    = intval( $input['max_file_size'] );
 			$output['max_file_size'] = max( 1, min( 100, $size ) );
 		}
 
-		// Sanitize checkboxes
-		$output['enable_debugging'] = isset( $input['enable_debugging'] ) ? '1' : '0';
-		$output['lazy_loading'] = isset( $input['lazy_loading'] ) ? '1' : '0';
+			// Sanitize checkboxes.
+		$output['enable_debugging']     = isset( $input['enable_debugging'] ) ? '1' : '0';
+		$output['lazy_loading']         = isset( $input['lazy_loading'] ) ? '1' : '0';
 		$output['enable_ar_by_default'] = isset( $input['enable_ar_by_default'] ) ? '1' : '0';
 
 		return $output;
@@ -534,70 +511,72 @@ class WP_3D_Model_Viewer_Admin {
 			<h1><?php echo esc_html( get_admin_page_title() ); ?></h1>
 			
 			<?php
-			// Display success message if settings saved
-			if ( isset( $_GET['settings-updated'] ) ) {
-				add_settings_error( 'wp_3d_model_viewer_messages', 'wp_3d_model_viewer_message', __( 'Settings saved.', 'wp-3d-model-viewer' ), 'updated' );
+						// Display success message if settings saved.
+			if ( isset( $_GET['settings-updated'] ) ) { // phpcs:ignore WordPress.Security.NonceVerification.Recommended
+				add_settings_error( 'wp_3d_model_viewer_messages', 'wp_3d_model_viewer_message', esc_html__( 'Settings saved.', 'wp-3d-model-viewer' ), 'updated' );
 			}
-			
-			// Display any error messages
+
+						// Display any error messages.
 			settings_errors( 'wp_3d_model_viewer_messages' );
 			?>
 			
 			<form action="options.php" method="post">
 				<?php
-				// Output security fields for the registered setting
-				settings_fields( 'wp_3d_model_viewer_options_group' );
-				
-				// Output setting sections and their fields
+								// Output security fields for the registered setting.
+								settings_fields( 'wp_3d_model_viewer_settings' );
+
+								// Output setting sections and their fields.
 				do_settings_sections( 'wp-3d-model-viewer' );
-				
-				// Output save settings button
-				submit_button( __( 'Save Settings', 'wp-3d-model-viewer' ) );
+
+								// Output save settings button.
+								submit_button( esc_html__( 'Save Settings', 'wp-3d-model-viewer' ) );
 				?>
 			</form>
 			
 			<div class="wp-3d-model-viewer-help">
-				<h2><?php _e( 'Usage Examples', 'wp-3d-model-viewer' ); ?></h2>
-				<p><?php _e( 'Use these shortcode examples to display 3D models:', 'wp-3d-model-viewer' ); ?></p>
-				
-				<h3><?php _e( 'Display a specific 3D model by ID:', 'wp-3d-model-viewer' ); ?></h3>
+								<h2><?php esc_html_e( 'Usage Examples', 'wp-3d-model-viewer' ); ?></h2>
+								<p><?php esc_html_e( 'Use these shortcode examples to display 3D models:', 'wp-3d-model-viewer' ); ?></p>
+
+								<h3><?php esc_html_e( 'Display a specific 3D model by ID:', 'wp-3d-model-viewer' ); ?></h3>
 				<code>[model_viewer id="123"]</code><br>
 				<code>[3d_model id="123"]</code><br>
 				<code>[3d_model_viewer id="123"]</code>
 				
-				<h3><?php _e( 'Display a model with custom settings:', 'wp-3d-model-viewer' ); ?></h3>
+								<h3><?php esc_html_e( 'Display a model with custom settings:', 'wp-3d-model-viewer' ); ?></h3>
 				<code>[model_viewer id="123" background-color="#ff0000" camera-orbit="45deg 75deg auto"]</code>
 				
-				<h3><?php _e( 'Display a model from external URL:', 'wp-3d-model-viewer' ); ?></h3>
+								<h3><?php esc_html_e( 'Display a model from external URL:', 'wp-3d-model-viewer' ); ?></h3>
 				<code>[3d_model_viewer src="https://example.com/model.glb" width="800px" height="600px"]</code>
 				
-				<h3><?php _e( 'Enable AR viewing:', 'wp-3d-model-viewer' ); ?></h3>
+								<h3><?php esc_html_e( 'Enable AR viewing:', 'wp-3d-model-viewer' ); ?></h3>
 				<code>[model_viewer id="123" ar ar-modes="webxr scene-viewer quick-look"]</code>
 			</div>
-		</div>
-		<?php
+				</div>
+				<?php
 	}
-	 *
-	 * @since    1.0.0
-	 */
+
+		/**
+		 * Add settings link to plugin list.
+		 *
+		 * @since 1.0.0
+		 *
+		 * @param array $links Existing plugin action links.
+		 * @return array
+		 */
 	public function add_action_links( $links ) {
-		/*
-		*  Documentation : https://codex.wordpress.org/Plugin_API/Filter_Reference/plugin_action_links_(plugin_file_name)
-		*/
-		$settings_link = array(
-			'<a href="' . admin_url( 'options-general.php?page=' . $this->plugin_name ) . '">' . __('Settings', $this->plugin_name) . '</a>',
-		);
-		return array_merge(  $settings_link, $links );
-
+			$settings_link = array(
+				'<a href="' . esc_url( admin_url( 'options-general.php?page=wp-3d-model-viewer' ) ) . '">' . esc_html__( 'Settings', 'wp-3d-model-viewer' ) . '</a>',
+			);
+			return array_merge( $settings_link, $links );
 	}
 
-	/**
-	 * Render the settings page for this plugin.
-	 *
-	 * @since    1.0.0
-	 */
+		/**
+		 * Render the settings page for this plugin.
+		 *
+		 * @since 1.0.0
+		 */
 	public function display_plugin_setup_page() {
-		include_once( 'partials/wp-3d-model-viewer-admin-display.php' );
+			include_once 'partials/wp-3d-model-viewer-admin-display.php';
 	}
 
 	/**
@@ -606,43 +585,45 @@ class WP_3D_Model_Viewer_Admin {
 	 * @since    1.0.0
 	 */
 	public function save_settings() {
-		
-		// Verify nonce
-		if ( ! wp_verify_nonce( $_POST['wp_3d_model_viewer_nonce'], 'wp_3d_model_viewer_save_settings' ) ) {
+
+				// Verify nonce.
+				$nonce = isset( $_POST['wp_3d_model_viewer_nonce'] ) ? sanitize_text_field( wp_unslash( $_POST['wp_3d_model_viewer_nonce'] ) ) : '';
+		if ( ! $nonce || ! wp_verify_nonce( $nonce, 'wp_3d_model_viewer_save_settings' ) ) {
 			wp_die( 'Security check failed' );
 		}
 
-		// Check user capabilities
+				// Check user capabilities.
 		if ( ! current_user_can( 'manage_options' ) ) {
 			wp_die( 'Insufficient permissions' );
 		}
 
 		$settings = array();
-		
-		// Sanitize and save settings
-		$settings['default_width'] = sanitize_text_field( $_POST['default_width'] ?? '100%' );
-		$settings['default_height'] = sanitize_text_field( $_POST['default_height'] ?? '400px' );
-		$settings['default_background_color'] = sanitize_hex_color( $_POST['default_background_color'] ?? '#ffffff' );
-		$settings['enable_ar_by_default'] = isset( $_POST['enable_ar_by_default'] ) ? 1 : 0;
-		$settings['enable_auto_rotate_by_default'] = isset( $_POST['enable_auto_rotate_by_default'] ) ? 1 : 0;
-		$settings['enable_camera_controls_by_default'] = isset( $_POST['enable_camera_controls_by_default'] ) ? 1 : 0;
-		$settings['max_file_size'] = absint( $_POST['max_file_size'] ?? 10485760 );
-		$settings['lazy_loading'] = isset( $_POST['lazy_loading'] ) ? 1 : 0;
-		$settings['compression_enabled'] = isset( $_POST['compression_enabled'] ) ? 1 : 0;
 
-		// Save allowed file types
-		$allowed_types = array();
-		if ( isset( $_POST['allowed_file_types'] ) && is_array( $_POST['allowed_file_types'] ) ) {
-			foreach ( $_POST['allowed_file_types'] as $type ) {
-				$allowed_types[] = sanitize_text_field( $type );
+				// Sanitize and save settings.
+				$settings['default_width']             = isset( $_POST['default_width'] ) ? sanitize_text_field( wp_unslash( $_POST['default_width'] ) ) : '100%';
+				$settings['default_height']            = isset( $_POST['default_height'] ) ? sanitize_text_field( wp_unslash( $_POST['default_height'] ) ) : '400px';
+				$settings['default_background_color']  = isset( $_POST['default_background_color'] ) ? sanitize_hex_color( wp_unslash( $_POST['default_background_color'] ) ) : '#ffffff';
+		$settings['enable_ar_by_default']              = isset( $_POST['enable_ar_by_default'] ) ? 1 : 0;
+		$settings['enable_auto_rotate_by_default']     = isset( $_POST['enable_auto_rotate_by_default'] ) ? 1 : 0;
+		$settings['enable_camera_controls_by_default'] = isset( $_POST['enable_camera_controls_by_default'] ) ? 1 : 0;
+				$settings['max_file_size']             = isset( $_POST['max_file_size'] ) ? absint( wp_unslash( $_POST['max_file_size'] ) ) : 10485760;
+		$settings['lazy_loading']                      = isset( $_POST['lazy_loading'] ) ? 1 : 0;
+		$settings['compression_enabled']               = isset( $_POST['compression_enabled'] ) ? 1 : 0;
+
+				// Save allowed file types.
+				$allowed_types = array();
+				$raw_types     = isset( $_POST['allowed_file_types'] ) ? array_map( 'sanitize_text_field', wp_unslash( (array) $_POST['allowed_file_types'] ) ) : array();
+		if ( is_array( $raw_types ) ) {
+			foreach ( $raw_types as $type ) {
+						$allowed_types[] = $type;
 			}
 		}
-		$settings['allowed_file_types'] = $allowed_types;
+				$settings['allowed_file_types'] = $allowed_types;
 
 		update_option( 'wp_3d_model_viewer_settings', $settings );
 
-		// Redirect with success message
-		wp_redirect( add_query_arg( 'settings-updated', 'true', wp_get_referer() ) );
+				// Redirect with success message.
+				wp_safe_redirect( add_query_arg( 'settings-updated', 'true', wp_get_referer() ) );
 		exit;
 	}
 
@@ -654,19 +635,18 @@ class WP_3D_Model_Viewer_Admin {
 	 */
 	public function get_settings() {
 		$default_settings = array(
-			'default_width' => '100%',
-			'default_height' => '400px',
-			'default_background_color' => '#ffffff',
-			'enable_ar_by_default' => false,
-			'enable_auto_rotate_by_default' => false,
+			'default_width'                     => '100%',
+			'default_height'                    => '400px',
+			'default_background_color'          => '#ffffff',
+			'enable_ar_by_default'              => false,
+			'enable_auto_rotate_by_default'     => false,
 			'enable_camera_controls_by_default' => true,
-			'max_file_size' => 10485760, // 10MB
-			'allowed_file_types' => array( 'gltf', 'glb', 'obj', 'fbx', 'dae', 'usdz' ),
-			'lazy_loading' => true,
-			'compression_enabled' => true,
+			'max_file_size'                     => 10485760, // 10MB.
+			'allowed_file_types'                => array( 'gltf', 'glb', 'obj', 'fbx', 'dae', 'usdz' ),
+			'lazy_loading'                      => true,
+			'compression_enabled'               => true,
 		);
 
 		return wp_parse_args( get_option( 'wp_3d_model_viewer_settings', array() ), $default_settings );
 	}
-
 }

--- a/includes/class-wp-3d-model-viewer.php
+++ b/includes/class-wp-3d-model-viewer.php
@@ -1,5 +1,4 @@
 <?php
-
 /**
  * The file that defines the core plugin class
  *
@@ -79,7 +78,6 @@ class WP_3D_Model_Viewer {
 		$this->define_admin_hooks();
 		$this->define_cpt_hooks();
 		$this->define_public_hooks();
-
 	}
 
 	/**
@@ -104,32 +102,31 @@ class WP_3D_Model_Viewer {
 		 * The class responsible for orchestrating the actions and filters of the
 		 * core plugin.
 		 */
-		require_once plugin_dir_path( dirname( __FILE__ ) ) . 'includes/class-wp-3d-model-viewer-loader.php';
+		require_once plugin_dir_path( __DIR__ ) . 'includes/class-wp-3d-model-viewer-loader.php';
 
 		/**
 		 * The class responsible for defining internationalization functionality
 		 * of the plugin.
 		 */
-		require_once plugin_dir_path( dirname( __FILE__ ) ) . 'includes/class-wp-3d-model-viewer-i18n.php';
+		require_once plugin_dir_path( __DIR__ ) . 'includes/class-wp-3d-model-viewer-i18n.php';
 
 		/**
 		 * The class responsible for defining all actions that occur in the admin area.
 		 */
-		require_once plugin_dir_path( dirname( __FILE__ ) ) . 'admin/class-wp-3d-model-viewer-admin.php';
+		require_once plugin_dir_path( __DIR__ ) . 'admin/class-wp-3d-model-viewer-admin.php';
 
 		/**
 		 * The class responsible for defining all actions that occur in the public-facing
 		 * side of the site.
 		 */
-		require_once plugin_dir_path( dirname( __FILE__ ) ) . 'public/class-wp-3d-model-viewer-public.php';
+		require_once plugin_dir_path( __DIR__ ) . 'public/class-wp-3d-model-viewer-public.php';
 
 		/**
 		 * The class responsible for defining the custom post type functionality.
 		 */
-		require_once plugin_dir_path( dirname( __FILE__ ) ) . 'includes/class-wp-3d-model-viewer-cpt.php';
+		require_once plugin_dir_path( __DIR__ ) . 'includes/class-wp-3d-model-viewer-cpt.php';
 
 		$this->loader = new WP_3D_Model_Viewer_Loader();
-
 	}
 
 	/**
@@ -146,7 +143,6 @@ class WP_3D_Model_Viewer {
 		$plugin_i18n = new WP_3D_Model_Viewer_i18n();
 
 		$this->loader->add_action( 'plugins_loaded', $plugin_i18n, 'load_plugin_textdomain' );
-
 	}
 
 	/**
@@ -164,17 +160,15 @@ class WP_3D_Model_Viewer {
 		$this->loader->add_action( 'admin_enqueue_scripts', $plugin_admin, 'enqueue_scripts' );
 		$this->loader->add_action( 'admin_init', $plugin_admin, 'admin_init' );
 
-		// Add menu
-		$this->loader->add_action( 'admin_menu', $plugin_admin, 'add_plugin_admin_menu' );
-		$this->loader->add_action( 'admin_menu', $plugin_admin, 'add_options_page' );
+								// Add settings page.
+				$this->loader->add_action( 'admin_menu', $plugin_admin, 'add_options_page' );
 
-		// Add Settings link to the plugin
+				// Add Settings link to the plugin.
 		$plugin_basename = plugin_basename( plugin_dir_path( __DIR__ ) . 'wp-3d-model-viewer.php' );
 		$this->loader->add_filter( 'plugin_action_links_' . $plugin_basename, $plugin_admin, 'add_action_links' );
 
-		// Handle settings save
+				// Handle settings save.
 		$this->loader->add_action( 'admin_post_wp_3d_model_viewer_save_settings', $plugin_admin, 'save_settings' );
-
 	}
 
 	/**
@@ -188,21 +182,20 @@ class WP_3D_Model_Viewer {
 
 		$plugin_cpt = new WP_3D_Model_Viewer_CPT();
 
-		// Register the custom post type
+				// Register the custom post type.
 		$this->loader->add_action( 'init', $plugin_cpt, 'register_post_type' );
 
-		// Add admin columns
+				// Add admin columns.
 		$this->loader->add_filter( 'manage_3d_model_posts_columns', $plugin_cpt, 'add_admin_columns' );
 		$this->loader->add_action( 'manage_3d_model_posts_custom_column', $plugin_cpt, 'populate_admin_columns', 10, 2 );
 		$this->loader->add_filter( 'manage_edit-3d_model_sortable_columns', $plugin_cpt, 'make_columns_sortable' );
 
-		// Add metaboxes
+				// Add metaboxes.
 		$this->loader->add_action( 'add_meta_boxes', $plugin_cpt, 'add_metaboxes' );
 		$this->loader->add_action( 'save_post', $plugin_cpt, 'save_metabox_data' );
 
-		// Enqueue admin scripts
+				// Enqueue admin scripts.
 		$this->loader->add_action( 'admin_enqueue_scripts', $plugin_cpt, 'enqueue_admin_scripts' );
-
 	}
 
 	/**
@@ -219,12 +212,11 @@ class WP_3D_Model_Viewer {
 		$this->loader->add_action( 'wp_enqueue_scripts', $plugin_public, 'enqueue_styles' );
 		$this->loader->add_action( 'wp_enqueue_scripts', $plugin_public, 'enqueue_scripts' );
 
-		// Add shortcode
+				// Add shortcode.
 		$this->loader->add_action( 'init', $plugin_public, 'register_shortcode' );
 
-		// Add Gutenberg block
+				// Add Gutenberg block.
 		$this->loader->add_action( 'init', $plugin_public, 'register_block' );
-
 	}
 
 	/**
@@ -266,5 +258,4 @@ class WP_3D_Model_Viewer {
 	public function get_version() {
 		return $this->version;
 	}
-
 }


### PR DESCRIPTION
## Summary
- use single `wp_3d_model_viewer_settings` group for registering and rendering settings
- drop duplicate admin menu hook so only one settings page is added
- escape translated strings and sanitize form inputs to satisfy WordPress coding standards

## Testing
- `composer phpcs` *(fails: The file "src/" does not exist)*
- `vendor/bin/phpcs --standard=WordPress admin/class-wp-3d-model-viewer-admin.php includes/class-wp-3d-model-viewer.php`
- `composer test` *(fails: displays phpunit usage instructions)*
- `npm test` *(fails: jest-environment-jsdom cannot be found)*

------
https://chatgpt.com/codex/tasks/task_e_6893b9ccc59883339ea6f852915e4bb6